### PR TITLE
remove install-go-tools

### DIFF
--- a/go-gemini/.idx/dev.nix
+++ b/go-gemini/.idx/dev.nix
@@ -12,15 +12,6 @@
   idx.extensions = [
     "golang.go"
   ];
-  idx.workspace = {
-    # runs when a workspace is first created with this `dev.nix` file
-    # to run something each time the environment is rebuilt, use the `onStart` hook
-    onCreate = {
-      install-go-tools = ''
-        go install golang.org/x/tools/gopls@latest
-      '';
-      };
-  };
   # preview configuration, identical to monospace.json
   idx.previews = {
     enable = true;

--- a/go-gemini/static/main.js
+++ b/go-gemini/static/main.js
@@ -8,11 +8,11 @@ form.onsubmit = async (ev) => {
     var data = new FormData(form);
     var request = new XMLHttpRequest();
     request.open("POST", "/api/generate");
-    request.send(data);
     request.onload = function () {
         // Read the response and interpret the output as markdown.
         let md = window.markdownit();
         output.innerHTML = md.render(request.responseText);
     };
+    request.send(data);
     return false;
 }


### PR DESCRIPTION
vscode-go handles tool installation as of v0.41.0, don't need idx to install tools. 